### PR TITLE
Unhide student-generated certificates toggle

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -50,7 +50,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         % endif
     </div>
 
-    % if not section_data['is_self_paced']:
     <hr />
 
     <div class="enable-certificates">
@@ -72,7 +71,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             <button class="is-disabled" disabled>${_('Enable Student-Generated Certificates')}</button>
         % endif
     </div>
-    % endif
 
     % if section_data['instructor_generation_enabled'] and not (section_data['enabled_for_course'] and section_data['html_cert_enabled']):
     <hr class="section-divider" />


### PR DESCRIPTION
Student-generated certificates are meant to be auto-enabled through
signal for self-paced courses, but it has been observed that this
behaviour is flaky. When this happens, we are left in a state where it
is impossible to enable student-generated certificates because the
section is hidden in the instructor dashboard.

Also by unconditionally displaying the toggle button, this allows more
flexibility for instructors. For example, it may be desirable for
student-generated certificates to be disabled for a self-paced course.