### PR TITLE
Use "Authorization: Bearer <token>" header for Badgr API

### DIFF
--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -162,7 +162,7 @@ class BadgrBackend(BadgeBackend):
         """
         Headers to send along with the request-- used for authentication.
         """
-        return {'Authorization': u'Token {}'.format(settings.BADGR_API_TOKEN)}
+        return {'Authorization': u'Bearer {}'.format(settings.BADGR_API_TOKEN)}
 
     def _ensure_badge_created(self, badge_class):
         """


### PR DESCRIPTION
Using the Authorization header as "Token <token>" is no longer supported.
To be able to use the Badgr API we'll need to update it to: "Bearer <token>".

(cherry picked from commit c65bfe7ed40b802d4240fc3177400e7824b972e4)